### PR TITLE
Add temporary workaround for bug in Safari 15.5+

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+/docs/style.css

--- a/docs/.prettierignore
+++ b/docs/.prettierignore
@@ -1,3 +1,1 @@
-.cache
-package-lock.json
-public
+style.css

--- a/docs/package.json
+++ b/docs/package.json
@@ -22,12 +22,10 @@
     "gatsby-plugin-postcss": "^3.7.0",
     "gatsby-plugin-typescript": "^2.12.1",
     "postcss": "^8.3.2",
-    "prettier": "^2.3.1",
     "typescript": "^4.3.2"
   },
   "scripts": {
     "build": "gatsby build",
-    "format": "prettier --write '**/*.{js,json,ts,tsx}'",
     "serve": "npm run build && gatsby serve",
     "start": "gatsby develop",
     "ts": "tsc"

--- a/docs/style.css
+++ b/docs/style.css
@@ -12,54 +12,67 @@
 svg * { transform-origin: 50% }
 
 @keyframes rotate {
+  0% { }
   100% { transform: rotate(360deg) }
 }
 
 @keyframes rotate_back {
+  0% { }
   100% { transform: rotate(-360deg) }
 }
 
 @keyframes sway {
+  0% { }
   100% { transform: translateX(10%) }
 }
 
 @keyframes drop {
+  0% { }
   100% { transform: translateY(45%) }
 }
 
 @keyframes rise {
+  0% { }
   100% { transform: translateY(-20%) }
 }
 
 @keyframes hero_one {
+  0% { }
   100% { transform: rotate(360deg) translate(17.5%, 17.5%) }
 }
 
 @keyframes hero_two {
+  0% { }
   100% { transform: rotate(360deg) translate(17.5%, -17.5%) }
 }
 
 @keyframes hero_three {
+  0% { }
   100% { transform: rotate(360deg) translate(-17.5%, 17.5%) }
 }
 
 @keyframes hero_four {
+  0% { }
   100% { transform: rotate(360deg) translate(-17.5%, -17.5%) }
 }
 
 @keyframes blob_one {
+  0% { }
   100% { transform: rotate(-360deg) translate(-12.5%, -12.5%) }
 }
 
 @keyframes blob_two {
+  0% { }
   100% { transform: rotate(-360deg) translate(12.5%, -12.5%) }
 }
 
 @keyframes blob_three {
+  0% { }
   100% { transform: rotate(-360deg) translate(-12.5%, 12.5%) }
 }
 
 @keyframes blob_four {
+  0% { }
   100% { transform: rotate(-360deg) translate(-12.5%, -12.5%) }
 }
 


### PR DESCRIPTION
Closes https://github.com/luukdv/gooey-react/issues/5.

Safari 15.5+ doesn't apply keyframes anymore when only their end state is defined (see [issue](https://github.com/luukdv/gooey-react/issues/5) for more details). This PR adds a temporary workaround until the issue is resolved.